### PR TITLE
Added missing </layer> XML tags closing the DB layer

### DIFF
--- a/experiments/layouts/fontes18/1bitAdderAOIG.sqd
+++ b/experiments/layouts/fontes18/1bitAdderAOIG.sqd
@@ -6,7 +6,7 @@
         <available_at>https://github.com/marcelwa/fiction</available_at>
         <date>Wed Mar  9 14:36:07 2022</date>
     </program>
-<layers>
+    <layers>
         <layer_prop>
             <name>Lattice</name>
             <type>Lattice</type>
@@ -2075,5 +2075,6 @@
                 <latcoord n="142" m="102" l="0"/>
                 <color>#ffc8c8c8</color>
             </dbdot>
+        </layer>
     </design>
 </siqad>

--- a/experiments/layouts/fontes18/1bitAdderMaj.sqd
+++ b/experiments/layouts/fontes18/1bitAdderMaj.sqd
@@ -6,7 +6,7 @@
         <available_at>https://github.com/marcelwa/fiction</available_at>
         <date>Wed Mar  9 14:36:08 2022</date>
     </program>
-<layers>
+    <layers>
         <layer_prop>
             <name>Lattice</name>
             <type>Lattice</type>
@@ -1330,5 +1330,6 @@
                 <latcoord n="175" m="44" l="0"/>
                 <color>#ffc8c8c8</color>
             </dbdot>
+        </layer>
     </design>
 </siqad>

--- a/experiments/layouts/fontes18/c17.sqd
+++ b/experiments/layouts/fontes18/c17.sqd
@@ -6,7 +6,7 @@
         <available_at>https://github.com/marcelwa/fiction</available_at>
         <date>Wed Mar  9 14:36:07 2022</date>
     </program>
-<layers>
+    <layers>
         <layer_prop>
             <name>Lattice</name>
             <type>Lattice</type>
@@ -2035,5 +2035,6 @@
                 <latcoord n="87" m="97" l="1"/>
                 <color>#ffc8c8c8</color>
             </dbdot>
+        </layer>
     </design>
 </siqad>

--- a/experiments/layouts/fontes18/cm82a_5.sqd
+++ b/experiments/layouts/fontes18/cm82a_5.sqd
@@ -6,7 +6,7 @@
         <available_at>https://github.com/marcelwa/fiction</available_at>
         <date>Wed Mar  9 14:47:52 2022</date>
     </program>
-<layers>
+    <layers>
         <layer_prop>
             <name>Lattice</name>
             <type>Lattice</type>
@@ -6110,5 +6110,6 @@
                 <latcoord n="264" m="203" l="0"/>
                 <color>#ffc8c8c8</color>
             </dbdot>
+        </layer>
     </design>
 </siqad>

--- a/experiments/layouts/fontes18/majority.sqd
+++ b/experiments/layouts/fontes18/majority.sqd
@@ -6,7 +6,7 @@
         <available_at>https://github.com/marcelwa/fiction</available_at>
         <date>Wed Mar  9 14:36:08 2022</date>
     </program>
-<layers>
+    <layers>
         <layer_prop>
             <name>Lattice</name>
             <type>Lattice</type>
@@ -3310,5 +3310,6 @@
                 <latcoord n="160" m="103" l="0"/>
                 <color>#ffc8c8c8</color>
             </dbdot>
+        </layer>
     </design>
 </siqad>

--- a/experiments/layouts/fontes18/majority_5_r1.sqd
+++ b/experiments/layouts/fontes18/majority_5_r1.sqd
@@ -6,7 +6,7 @@
         <available_at>https://github.com/marcelwa/fiction</available_at>
         <date>Wed Mar  9 14:36:08 2022</date>
     </program>
-<layers>
+    <layers>
         <layer_prop>
             <name>Lattice</name>
             <type>Lattice</type>
@@ -3740,5 +3740,6 @@
                 <latcoord n="238" m="49" l="0"/>
                 <color>#ffc8c8c8</color>
             </dbdot>
+        </layer>
     </design>
 </siqad>

--- a/experiments/layouts/fontes18/newtag.sqd
+++ b/experiments/layouts/fontes18/newtag.sqd
@@ -6,7 +6,7 @@
         <available_at>https://github.com/marcelwa/fiction</available_at>
         <date>Wed Mar  9 14:36:08 2022</date>
     </program>
-<layers>
+    <layers>
         <layer_prop>
             <name>Lattice</name>
             <type>Lattice</type>
@@ -3310,5 +3310,6 @@
                 <latcoord n="424" m="40" l="0"/>
                 <color>#ffc8c8c8</color>
             </dbdot>
+        </layer>
     </design>
 </siqad>

--- a/experiments/layouts/fontes18/t.sqd
+++ b/experiments/layouts/fontes18/t.sqd
@@ -6,7 +6,7 @@
         <available_at>https://github.com/marcelwa/fiction</available_at>
         <date>Wed Mar  9 14:36:07 2022</date>
     </program>
-<layers>
+    <layers>
         <layer_prop>
             <name>Lattice</name>
             <type>Lattice</type>
@@ -2185,5 +2185,6 @@
                 <latcoord n="181" m="79" l="1"/>
                 <color>#ffc8c8c8</color>
             </dbdot>
+        </layer>
     </design>
 </siqad>

--- a/experiments/layouts/fontes18/t_5.sqd
+++ b/experiments/layouts/fontes18/t_5.sqd
@@ -6,7 +6,7 @@
         <available_at>https://github.com/marcelwa/fiction</available_at>
         <date>Wed Mar  9 14:36:07 2022</date>
     </program>
-<layers>
+    <layers>
         <layer_prop>
             <name>Lattice</name>
             <type>Lattice</type>
@@ -2295,5 +2295,6 @@
                 <latcoord n="123" m="76" l="1"/>
                 <color>#ffc8c8c8</color>
             </dbdot>
+        </layer>
     </design>
 </siqad>

--- a/experiments/layouts/fontes18/xor.sqd
+++ b/experiments/layouts/fontes18/xor.sqd
@@ -6,7 +6,7 @@
         <available_at>https://github.com/marcelwa/fiction</available_at>
         <date>Wed Mar  9 14:36:07 2022</date>
     </program>
-<layers>
+    <layers>
         <layer_prop>
             <name>Lattice</name>
             <type>Lattice</type>
@@ -345,5 +345,6 @@
                 <latcoord n="106" m="19" l="0"/>
                 <color>#ffc8c8c8</color>
             </dbdot>
+        </layer>
     </design>
 </siqad>

--- a/experiments/layouts/fontes18/xor5Maj.sqd
+++ b/experiments/layouts/fontes18/xor5Maj.sqd
@@ -6,7 +6,7 @@
         <available_at>https://github.com/marcelwa/fiction</available_at>
         <date>Wed Mar  9 14:47:52 2022</date>
     </program>
-<layers>
+    <layers>
         <layer_prop>
             <name>Lattice</name>
             <type>Lattice</type>
@@ -1275,5 +1275,6 @@
                 <latcoord n="270" m="26" l="1"/>
                 <color>#ffc8c8c8</color>
             </dbdot>
+        </layer>
     </design>
 </siqad>

--- a/experiments/layouts/fontes18/xor5_r1.sqd
+++ b/experiments/layouts/fontes18/xor5_r1.sqd
@@ -6,7 +6,7 @@
         <available_at>https://github.com/marcelwa/fiction</available_at>
         <date>Wed Mar  9 14:36:08 2022</date>
     </program>
-<layers>
+    <layers>
         <layer_prop>
             <name>Lattice</name>
             <type>Lattice</type>
@@ -1215,5 +1215,6 @@
                 <latcoord n="84" m="23" l="0"/>
                 <color>#ffc8c8c8</color>
             </dbdot>
+        </layer>
     </design>
 </siqad>

--- a/experiments/layouts/trindade16/FA.sqd
+++ b/experiments/layouts/trindade16/FA.sqd
@@ -6,7 +6,7 @@
         <available_at>https://github.com/marcelwa/fiction</available_at>
         <date>Wed Mar  9 14:36:07 2022</date>
     </program>
-<layers>
+    <layers>
         <layer_prop>
             <name>Lattice</name>
             <type>Lattice</type>
@@ -2075,5 +2075,6 @@
                 <latcoord n="142" m="102" l="0"/>
                 <color>#ffc8c8c8</color>
             </dbdot>
+        </layer>
     </design>
 </siqad>

--- a/experiments/layouts/trindade16/HA.sqd
+++ b/experiments/layouts/trindade16/HA.sqd
@@ -6,7 +6,7 @@
         <available_at>https://github.com/marcelwa/fiction</available_at>
         <date>Wed Mar  9 14:36:07 2022</date>
     </program>
-<layers>
+    <layers>
         <layer_prop>
             <name>Lattice</name>
             <type>Lattice</type>
@@ -920,5 +920,6 @@
                 <latcoord n="142" m="68" l="0"/>
                 <color>#ffc8c8c8</color>
             </dbdot>
+        </layer>
     </design>
 </siqad>

--- a/experiments/layouts/trindade16/mux21.sqd
+++ b/experiments/layouts/trindade16/mux21.sqd
@@ -6,7 +6,7 @@
         <available_at>https://github.com/marcelwa/fiction</available_at>
         <date>Wed Mar  9 14:36:07 2022</date>
     </program>
-<layers>
+    <layers>
         <layer_prop>
             <name>Lattice</name>
             <type>Lattice</type>
@@ -1035,5 +1035,6 @@
                 <latcoord n="177" m="45" l="0"/>
                 <color>#ffc8c8c8</color>
             </dbdot>
+        </layer>
     </design>
 </siqad>

--- a/experiments/layouts/trindade16/par_check.sqd
+++ b/experiments/layouts/trindade16/par_check.sqd
@@ -6,7 +6,7 @@
         <available_at>https://github.com/marcelwa/fiction</available_at>
         <date>Wed Mar  9 14:36:07 2022</date>
     </program>
-<layers>
+    <layers>
         <layer_prop>
             <name>Lattice</name>
             <type>Lattice</type>
@@ -1475,5 +1475,6 @@
                 <latcoord n="138" m="89" l="0"/>
                 <color>#ffc8c8c8</color>
             </dbdot>
+        </layer>
     </design>
 </siqad>

--- a/experiments/layouts/trindade16/par_gen.sqd
+++ b/experiments/layouts/trindade16/par_gen.sqd
@@ -6,7 +6,7 @@
         <available_at>https://github.com/marcelwa/fiction</available_at>
         <date>Wed Mar  9 14:36:07 2022</date>
     </program>
-<layers>
+    <layers>
         <layer_prop>
             <name>Lattice</name>
             <type>Lattice</type>
@@ -570,5 +570,6 @@
                 <latcoord n="100" m="21" l="0"/>
                 <color>#ffc8c8c8</color>
             </dbdot>
+        </layer>
     </design>
 </siqad>

--- a/experiments/layouts/trindade16/xnor2.sqd
+++ b/experiments/layouts/trindade16/xnor2.sqd
@@ -6,7 +6,7 @@
         <available_at>https://github.com/marcelwa/fiction</available_at>
         <date>Wed Mar  9 14:36:07 2022</date>
     </program>
-<layers>
+    <layers>
         <layer_prop>
             <name>Lattice</name>
             <type>Lattice</type>
@@ -345,5 +345,6 @@
                 <latcoord n="106" m="19" l="0"/>
                 <color>#ffc8c8c8</color>
             </dbdot>
+        </layer>
     </design>
 </siqad>

--- a/experiments/layouts/trindade16/xor2.sqd
+++ b/experiments/layouts/trindade16/xor2.sqd
@@ -6,7 +6,7 @@
         <available_at>https://github.com/marcelwa/fiction</available_at>
         <date>Wed Mar  9 14:36:07 2022</date>
     </program>
-<layers>
+    <layers>
         <layer_prop>
             <name>Lattice</name>
             <type>Lattice</type>
@@ -345,5 +345,6 @@
                 <latcoord n="106" m="19" l="0"/>
                 <color>#ffc8c8c8</color>
             </dbdot>
+        </layer>
     </design>
 </siqad>


### PR DESCRIPTION
The missing tag would create issues in opening the design files in the Windows version of SiQAD. It remained undetected because it worked in the Linux version.

This update does not alter any layout or simulation data! It simply ensures compatibility of the files for all SiQAD versions!